### PR TITLE
Change two symlinks of 'files' to use /var/db/repos/gentoo instead /usr/portage

### DIFF
--- a/dev-python/jsonschema/files
+++ b/dev-python/jsonschema/files
@@ -1,1 +1,1 @@
-/usr/portage/dev-python/jsonschema/files
+/var/db/repos/gentoo/dev-python/jsonschema/files

--- a/sys-apps/file/files
+++ b/sys-apps/file/files
@@ -1,1 +1,1 @@
-/usr/portage/sys-apps/file/files
+/var/db/repos/gentoo/sys-apps/file/files


### PR DESCRIPTION
Not sure exactly when `/usr/portage` stopped being available but at least on my system only `/var/db/repos/gentoo` location is available. Without the `/usr/portage` the the system update with the overlay active was not possible today.
I have pasted the `emerge --update --newuse --deep --with-bdeps=y --ask  @world` error output in the issue I have reported simultaneously.

Thanks,
Adam.